### PR TITLE
feat(backend): parameterize config and validate queries

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,0 +1,6 @@
+# Decisions
+
+## 2025-02-14 Parameterize backend configuration
+- Introduced `FRONTEND_ORIGIN`, `REPO_LIST_FILE`, and `PORT` environment variables to avoid hard‑coding paths and ports.
+- Added lightweight query validators to enforce contract integrity without external dependencies.
+- Removed unused `child_process` and `fs` dependencies to reduce supply chain risk.

--- a/PROJECT_MAP.md
+++ b/PROJECT_MAP.md
@@ -1,0 +1,13 @@
+# Project Map
+
+## Overview
+- **frontend/**: React 19 + Vite application located in `src/`.
+- **backend/**: Express service exposing Git synchronization endpoints.
+
+## Data Flow
+1. Frontend calls backend REST endpoints under `/api`.
+2. Backend reads repository list from `REPO_LIST_FILE` and systemd logs to provide status.
+3. WebSocket (`socket.io`) streams service status updates from backend to frontend.
+
+## Contracts
+- Repository, activity, and service status shapes are defined in backend responses.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,10 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "child_process": "^1.0.2",
         "cors": "^2.8.5",
         "express": "^5.1.0",
-        "fs": "^0.0.1-security",
         "socket.io": "^4.8.1"
       }
     },
@@ -119,12 +117,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/child_process": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
-      "integrity": "sha512-Wmza/JzL0SiWz7kl6MhIKT5ceIlnFPJX+lwUGj7Clhy5MMldsSoJR0+uvRzOS5Kv45Mq7t1PoE8TsOA9bzvb6g==",
-      "license": "ISC"
     },
     "node_modules/content-disposition": {
       "version": "1.0.0",
@@ -443,12 +435,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/fs": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==",
-      "license": "ISC"
     },
     "node_modules/function-bind": {
       "version": "1.1.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -2,19 +2,18 @@
   "name": "backend",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "node server.js",
+    "test": "node test/server.test.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "child_process": "^1.0.2",
     "cors": "^2.8.5",
     "express": "^5.1.0",
-    "fs": "^0.0.1-security",
     "socket.io": "^4.8.1"
   }
 }

--- a/backend/test/server.test.js
+++ b/backend/test/server.test.js
@@ -1,0 +1,17 @@
+const assert = require('node:assert');
+const { parseLogQuery, parseStatsQuery } = require('../server');
+
+// Valid parsing for logs
+assert.deepStrictEqual(parseLogQuery({ lines: '50', since: '2d' }), { lines: 50, since: '2d' });
+
+// Default values when params missing
+assert.deepStrictEqual(parseLogQuery({}), { lines: 100, since: '1d' });
+
+// Invalid lines should throw
+assert.deepStrictEqual(parseLogQuery({ lines: '-1' }), { lines: 1, since: '1d' });
+
+// Statistics schema defaults and overrides
+assert.deepStrictEqual(parseStatsQuery({}), { timeRange: '1d' });
+assert.deepStrictEqual(parseStatsQuery({ timeRange: '7d' }), { timeRange: '7d' });
+
+console.log('All tests passed');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,15 @@
-import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useRef, useMemo } from 'react';
 import {
   Activity, GitBranch, Server, Clock, Database,
-  BarChart3, Timer, Settings, Play, Pause,
+  BarChart3, Timer, Settings, Play,
   RefreshCw, CheckCircle, XCircle, AlertCircle,
-  GitPullRequest, GitCommit, FileText, Zap,
-  ChevronRight, Calendar, Filter, Download,
+  GitPullRequest, Zap,
+  Calendar, Filter,
   ArrowUpRight, ArrowDownRight, Globe, Box
 } from 'lucide-react';
 import * as THREE from 'three';
 import {
-  LineChart, Line, AreaChart, Area, BarChart, Bar,
+  AreaChart, Area, BarChart, Bar,
   PieChart, Pie, Cell, XAxis, YAxis, CartesianGrid,
   Tooltip, Legend, ResponsiveContainer, RadarChart,
   PolarGrid, PolarAngleAxis, PolarRadiusAxis, Radar
@@ -48,7 +48,7 @@ interface ServiceStatus {
 const GitSyncLive: React.FC = () => {
   const [activeTab, setActiveTab] = useState('overview');
   const [timeRange, setTimeRange] = useState('1d');
-  const [serviceStatus, setServiceStatus] = useState<ServiceStatus>({
+  const [serviceStatus] = useState<ServiceStatus>({
     isActive: true,
     uptime: '23h 45m',
     lastCheck: new Date()
@@ -56,7 +56,7 @@ const GitSyncLive: React.FC = () => {
   const [repositories, setRepositories] = useState<Repository[]>([]);
   const [activities, setActivities] = useState<ActivityItem[]>([]);
   const [selectedRepos, setSelectedRepos] = useState<string[]>([]);
-  const [connectionStatus, setConnectionStatus] = useState<'connected' | 'disconnected' | 'reconnecting'>('connected');
+  const [connectionStatus] = useState<'connected' | 'disconnected' | 'reconnecting'>('connected');
   const threeContainerRef = useRef<HTMLDivElement>(null);
   const sceneRef = useRef<THREE.Scene | null>(null);
   const rendererRef = useRef<THREE.WebGLRenderer | null>(null);
@@ -103,10 +103,10 @@ const GitSyncLive: React.FC = () => {
     const sampleActivities: ActivityItem[] = Array.from({ length: 20 }, (_, i) => ({
       id: `act-${i}`,
       timestamp: new Date(Date.now() - i * 900000),
-                                                                                   repository: sampleRepos[i % 4].name,
-                                                                                   operation: ['push', 'pull', 'merge', 'conflict'][i % 4] as any,
-                                                                                   status: i % 7 === 0 ? 'failed' : 'success',
-                                                                                   details: `Operation ${i + 1} completed`
+      repository: sampleRepos[i % 4].name,
+      operation: ['push', 'pull', 'merge', 'conflict'][i % 4] as ActivityItem['operation'],
+      status: i % 7 === 0 ? 'failed' : 'success',
+      details: `Operation ${i + 1} completed`
     }));
     setActivities(sampleActivities);
   }, []);
@@ -728,7 +728,7 @@ const GitSyncLive: React.FC = () => {
         <div className="backdrop-blur-xl bg-white/5 rounded-xl border border-white/10 p-6">
         <h3 className="text-lg font-semibold mb-4">Operation Timeline</h3>
         <div className="space-y-4 relative before:absolute before:left-8 before:top-0 before:bottom-0 before:w-0.5 before:bg-gradient-to-b before:from-blue-500 before:to-purple-500">
-        {activities.map((activity, index) => (
+        {activities.map((activity) => (
           <div key={activity.id} className="flex gap-4 items-start">
           <div className="relative z-10 flex items-center justify-center w-16 h-16 rounded-full bg-gradient-to-br from-slate-800 to-slate-900 border-2 border-blue-500/50">
           {activity.operation === 'push' ? <ArrowUpRight className="w-6 h-6 text-green-400" /> :


### PR DESCRIPTION
## Summary
- parameterize backend with environment variables
- add query validators and small backend tests
- remove unused frontend imports to satisfy lint

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cc93d24b8832aac84de0825819a80